### PR TITLE
Add link[rel=atlernate] with feed url

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -113,7 +113,7 @@ if data['site']
 end
 
 # Create RSS Feed xml
-page '/feed.xml', layout: false
+page data.config.feed_path, layout: false
 
 # Move partials out of the way of regular pages
 set :partials_dir, 'partials/'

--- a/data/config.yml
+++ b/data/config.yml
@@ -2,7 +2,8 @@ site_title: The Guild
 site_subtitle: The Guild of Artisans Masterclass in Development and Geekery
 author: Kabisa
 email: info@kabisa.nl
-host: www.theguild.nl
+site_url: http://www.theguild.nl
+feed_path: /feed.xml
 
 # Lookup table with IDs as used
 # by the corresponding entries in Contentful

--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -1,12 +1,13 @@
 xml.instruct!
 xml.feed xmlns: "http://www.w3.org/2005/Atom" do
-  site_url = "http://#{data.config.host}"
+  site_url = data.config.site_url
+  feed_path = data.config.feed_path
 
   xml.title "#{data.config.site_title}"
   xml.subtitle "#{data.config.site_subtitle}"
   xml.id URI(site_url)
   xml.link href: URI(site_url)
-  xml.link href: URI.join(site_url, "/feed.xml"), rel: "self"
+  xml.link href: URI.join(site_url, feed_path), rel: "self"
   xml.updated @posts.first.createdOn.to_time.iso8601
   xml.author do
     xml.name "#{data.config.author}"

--- a/source/partials/_head.html.slim
+++ b/source/partials/_head.html.slim
@@ -3,6 +3,7 @@ meta[content="width=device-width,initial-scale=1" name="viewport"]
 meta[content=(current_page.data.description || yield_content(:description) || data.config.description) name="description"]
 title= [data.config.site_title, current_page.data.title, yield_content(:title)].compact.join(' - ')
 = stylesheet_link_tag :site
+link rel="alternate" type="application/atom+xml" href=data.config.feed_path
 / TODO: Create a HTML5 link tag to the stylesheet, instead of the Ruby helper
 / link rel="stylesheet" href= :site
 |<script src="//use.typekit.net/wer4zsm.js"></script>


### PR DESCRIPTION
This is the canonical way to indicate your site supports feeds. Some
browsers will show an RSS icon in the url bar when a website serves this
tag.

Also puts the feed_path into the configuration, to prevent duplicaiton.
Also moved the site_url into the config, such that when we switch to
HTTPS for example you only need to save it in one place.
