### PR TITLE
Remove padding-left on posts-list

### DIFF
--- a/source/stylesheets/_posts.css.scss
+++ b/source/stylesheets/_posts.css.scss
@@ -71,6 +71,7 @@
 }
 .prose .posts-list {
   list-style: none;
+  padding-left: 0;
 }
 
 //


### PR DESCRIPTION
As discussed in https://github.com/kabisa/theguild.nl/pull/16 the posts-list should not get a left-padding. 

Fixes the following:

![a0ceb6bc-6a03-11e5-920a-e161f3192512](https://cloud.githubusercontent.com/assets/304603/10266770/c8b0b05a-6a75-11e5-80a0-daee0e7ade33.jpeg)
