### PR TITLE
Hide content length + reading time from index

### DIFF
--- a/source/partials/_post-teaser.html.slim
+++ b/source/partials/_post-teaser.html.slim
@@ -8,7 +8,6 @@ li
         => author.name
       ' on
       = post.createdOn.strftime('%-d %B %Y')
-      '  -
-      =< content_length_and_average_reading_time(post.body)
+      '
 
     p.excerpt= post.summary


### PR DESCRIPTION
This information clutters the view (especially on mobile) and probably
isn't interesting to readers when they're on the index page anyway.
Hopefully our readers pick articles based on interest, not reading
duration ;-)

Before:

![4da6e00a-95e0-11e5-9f1a-1cf0b59572da](https://cloud.githubusercontent.com/assets/304603/11465438/f088e8a0-9738-11e5-96db-1239ecc1ea7e.png)

After:

![screen shot 2015-11-30 at 08 00 29](https://cloud.githubusercontent.com/assets/304603/11465443/f36da128-9738-11e5-9c6f-b52c07c2de4c.png)

Also discussed in #50.
