### PR TITLE
Change syntax highlighting theme to Tomorrow Night

### DIFF
--- a/source/stylesheets/_syntax.css.scss.erb
+++ b/source/stylesheets/_syntax.css.scss.erb
@@ -1,7 +1,75 @@
-<%#- Rouge has ThankfulEyes, Colorful, Github, Base16, Base16::Monokai, -%>
-<%#- Base16::Solarized (like Octopress) and Monokai themes. -%>
+$background-color: #2d2d2d;
+$default-text-color: #eaeaea;
 
-<%= Rouge::Themes::Github.render(scope: '.highlight') %>
+td.code {
+  padding: 5px 5px 5px 10px;
+}
+
+.highlight .hll { background-color: #424242 }
+.highlight  { background: $background-color; color: $default-text-color }
+.highlight .c { color: #969896 } /* Comment */
+.highlight .err { color: #d54e53 } /* Error */
+.highlight .k { color: #c397d8 } /* Keyword */
+.highlight .l { color: #e78c45 } /* Literal */
+.highlight .n { color: #eaeaea } /* Name */
+.highlight .o { color: #70c0b1 } /* Operator */
+.highlight .p { color: #eaeaea } /* Punctuation */
+.highlight .cm { color: #969896 } /* Comment.Multiline */
+.highlight .cp { color: #969896 } /* Comment.Preproc */
+.highlight .c1 { color: #969896 } /* Comment.Single */
+.highlight .cs { color: #969896 } /* Comment.Special */
+.highlight .gd { color: #d54e53 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gh { color: #eaeaea; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #b9ca4a } /* Generic.Inserted */
+.highlight .gp { color: #969896; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #70c0b1; font-weight: bold } /* Generic.Subheading */
+.highlight .kc { color: #c397d8 } /* Keyword.Constant */
+.highlight .kd { color: #c397d8 } /* Keyword.Declaration */
+.highlight .kn { color: #70c0b1 } /* Keyword.Namespace */
+.highlight .kp { color: #c397d8 } /* Keyword.Pseudo */
+.highlight .kr { color: #c397d8 } /* Keyword.Reserved */
+.highlight .kt { color: #e7c547 } /* Keyword.Type */
+.highlight .ld { color: #b9ca4a } /* Literal.Date */
+.highlight .m { color: #e78c45 } /* Literal.Number */
+.highlight .s { color: #b9ca4a } /* Literal.String */
+.highlight .na { color: #7aa6da } /* Name.Attribute */
+.highlight .nb { color: #eaeaea } /* Name.Builtin */
+.highlight .nc { color: #e7c547 } /* Name.Class */
+.highlight .no { color: #d54e53 } /* Name.Constant */
+.highlight .nd { color: #70c0b1 } /* Name.Decorator */
+.highlight .ni { color: #eaeaea } /* Name.Entity */
+.highlight .ne { color: #d54e53 } /* Name.Exception */
+.highlight .nf { color: #7aa6da } /* Name.Function */
+.highlight .nl { color: #eaeaea } /* Name.Label */
+.highlight .nn { color: #e7c547 } /* Name.Namespace */
+.highlight .nx { color: #7aa6da } /* Name.Other */
+.highlight .py { color: #eaeaea } /* Name.Property */
+.highlight .nt { color: #70c0b1 } /* Name.Tag */
+.highlight .nv { color: #d54e53 } /* Name.Variable */
+.highlight .ow { color: #70c0b1 } /* Operator.Word */
+.highlight .w { color: #eaeaea } /* Text.Whitespace */
+.highlight .mf { color: #e78c45 } /* Literal.Number.Float */
+.highlight .mh { color: #e78c45 } /* Literal.Number.Hex */
+.highlight .mi { color: #e78c45 } /* Literal.Number.Integer */
+.highlight .mo { color: #e78c45 } /* Literal.Number.Oct */
+.highlight .sb { color: #b9ca4a } /* Literal.String.Backtick */
+.highlight .sc { color: #eaeaea } /* Literal.String.Char */
+.highlight .sd { color: #969896 } /* Literal.String.Doc */
+.highlight .s2 { color: #b9ca4a } /* Literal.String.Double */
+.highlight .se { color: #e78c45 } /* Literal.String.Escape */
+.highlight .sh { color: #b9ca4a } /* Literal.String.Heredoc */
+.highlight .si { color: #e78c45 } /* Literal.String.Interpol */
+.highlight .sx { color: #b9ca4a } /* Literal.String.Other */
+.highlight .sr { color: #b9ca4a } /* Literal.String.Regex */
+.highlight .s1 { color: #b9ca4a } /* Literal.String.Single */
+.highlight .ss { color: #b9ca4a } /* Literal.String.Symbol */
+.highlight .bp { color: #eaeaea } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #d54e53 } /* Name.Variable.Class */
+.highlight .vg { color: #d54e53 } /* Name.Variable.Global */
+.highlight .vi { color: #d54e53 } /* Name.Variable.Instance */
+.highlight .il { color: #e78c45 } /* Literal.Number.Integer.Long */
 
 .highlight {
   margin-bottom: 1em;
@@ -15,11 +83,12 @@
   }
   .gutter {
     width: 2.5em;
+    text-align: center !important;
   }
   .gl {
-    background: #fafafa;
+    background: $background-color;
     border-right: 1px solid #ddd;
-    color: #999;
+    color: $default-text-color;
 
     /* Stop line numbers being visually selected */
     user-select: none;


### PR DESCRIPTION
![old-vs-new](https://cloud.githubusercontent.com/assets/304603/13661024/7fc80a5a-e68f-11e5-9a20-aa483702995b.png)

Left: current. Right: proposed.

This changes the syntax highlighting theme to Tomorrow Night. This way the code stands out more, which I think for the kind of technical posts we write on the guild is important. I also think it just looks better :-)