### PR TITLE
Add some word-spacing to headers to make words look less crammed

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -33,8 +33,8 @@ h1, h2, h3, h4 {
 
   font-family: $heading-font;
   font-weight: $heading-weight;
-  // color: $brand-primary;
   text-transform: uppercase;
+  word-spacing: 0.1em;
 
   .prose & {
     // We only want top/bottom margin in prose


### PR DESCRIPTION
Words in headers look pretty crammed right now. This PR adds a bit of word-spacing.

Exhibit A:

![header-word-spacing](https://cloud.githubusercontent.com/assets/304603/17764283/a134e59c-651e-11e6-9c2a-936ee6546fd6.gif)

Exhibit B:

![header-word-spacing-2](https://cloud.githubusercontent.com/assets/304603/17764284/a3ab0b1c-651e-11e6-949e-5fca2f62f581.gif)
