### PR TITLE
Switch to GFM

### DIFF
--- a/helpers/markdown_helper.rb
+++ b/helpers/markdown_helper.rb
@@ -1,0 +1,5 @@
+module MarkdownHelper
+  def render_markdown(markdown)
+    Kramdown::Document.new(markdown, input: 'GFM', hard_wrap: false).to_html
+  end
+end

--- a/source/404.html.slim
+++ b/source/404.html.slim
@@ -8,4 +8,4 @@ header.hero.page-not-found
 
 main.post role="main"
   section.prose
-    = Kramdown::Document.new(page.body).to_html
+    = render_markdown(page.body)

--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -25,7 +25,7 @@ xml.feed xmlns: "http://www.w3.org/2005/Atom" do
         xml.author { xml.name author.name }
       end
       xml.summary post.summary, type: "html"
-      xml.content Kramdown::Document.new(post.body).to_html, type: "html"
+      xml.content render_markdown(post.body), type: "html"
     end
   end
 end

--- a/source/partials/_author-testimonial.slim
+++ b/source/partials/_author-testimonial.slim
@@ -3,4 +3,4 @@
     .image= image_tag author.profilePhoto.url
     .details
       h4= author.name
-      = Kramdown::Document.new(author.biography).to_html
+      = render_markdown(author.biography)

--- a/source/templates/post.html.slim
+++ b/source/templates/post.html.slim
@@ -25,7 +25,7 @@ main.post role="main"
           br
           =< content_length_and_average_reading_time(post.body)
 
-    = Kramdown::Document.new(post.body).to_html
+    = render_markdown(post.body)
 
     - post.authors.each do |author|
       = partial 'author-testimonial', locals: { author: author }
@@ -35,4 +35,3 @@ main.post role="main"
     = partial 'disqus', locals: { disqus_shortname: 'kabisa-blog' }
 
 = partial 'related-posts', locals: { posts: similar_posts(post, @posts) }
-


### PR DESCRIPTION
Since GFM is a superset of 'regular markdown' this should not break
anything. It does add several features documented
[here](https://help.github.com/enterprise/11.10.340/user/articles/github-flavored-markdown/).

Most notably:

* Fenced codeblocks
* Striketrough
* URL autolinking