### PR TITLE
Add rspec-middleman #47

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--require spec_helper
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,5 @@ group :development do
   gem 'rake'
   gem 'rspec'
   gem 'capybara'
+  gem 'poltergeist'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,10 @@ gem 'middleman-search_engine_sitemap'
 gem 'slim'
 gem 'html2slim' # Use `bundle exec erb2slim|html2slim -h` for more info
 gem 'builder' # XMLfeeds
+
+# Testing
+group :development do
+  gem 'rake'
+  gem 'rspec'
+  gem 'capybara'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     chunky_png (1.3.4)
+    cliver (0.3.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -43,6 +44,7 @@ GEM
       contentful (~> 0.8)
       contentful-webhook-listener (~> 0.1)
       middleman-core (~> 3.3)
+    diff-lcs (1.3)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (1.0.2)
@@ -134,15 +136,33 @@ GEM
       tilt (~> 1.4.1)
     padrino-support (0.12.5)
       activesupport (>= 3.1)
+    poltergeist (1.17.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     rack (1.6.4)
     rack-livereload (0.3.16)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rake (12.3.0)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rouge (1.9.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
     sass (3.4.17)
     slim (3.0.6)
       temple (~> 0.7.3)
@@ -170,6 +190,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    websocket-driver (0.7.0)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -178,6 +201,7 @@ PLATFORMS
 
 DEPENDENCIES
   builder
+  capybara
   contentful_middleman
   html2slim
   middleman
@@ -186,9 +210,15 @@ DEPENDENCIES
   middleman-livereload
   middleman-search_engine_sitemap
   middleman-syntax
+  poltergeist
+  rake
+  rspec
   slim
   tzinfo-data
   wdm (~> 0.1.0)
 
+RUBY VERSION
+   ruby 2.3.3p222
+
 BUNDLED WITH
-   1.10.6
+   1.16.1

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -14,5 +14,5 @@ main role="main"
 
   section
     .flex-posts-list
-      - @posts.each do |post|
+      - @posts&.each do |post|
         = partial 'post-teaser', locals: { post: post }

--- a/spec/features/index_spec.rb
+++ b/spec/features/index_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'index', :type => :feature do
+  before do
+    visit '/'
+  end
+
+  subject { page }
+
+  context 'without contentful data' do
+    it { is_expected.to have_selector('img[src*=theguild-logo]') }
+
+    it { is_expected.to have_content(/The Guild — A Blog About Development and Geekery/i) }
+    it { is_expected.to have_content(/Written by Kabisa/i) }
+  end
+end

--- a/spec/features/index_spec.rb
+++ b/spec/features/index_spec.rb
@@ -7,7 +7,7 @@ describe 'index', :type => :feature do
 
   subject { page }
 
-  context 'without contentful data' do
+  context 'without contentful data', js: true do
     it { is_expected.to have_selector('img[src*=theguild-logo]') }
 
     it { is_expected.to have_content(/The Guild — A Blog About Development and Geekery/i) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+require "middleman"
+require 'rspec'
+require 'capybara/rspec'
+
+Capybara.app = Middleman::Application.server.inst do
+  set :root, File.expand_path(File.join(File.dirname(__FILE__), '..'))
+  set :environment, :development
+  set :show_exceptions, false
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,19 @@
 require "middleman"
 require 'rspec'
 require 'capybara/rspec'
+require 'capybara/poltergeist'
+
+Capybara.javascript_driver = :poltergeist
 
 Capybara.app = Middleman::Application.server.inst do
   set :root, File.expand_path(File.join(File.dirname(__FILE__), '..'))
   set :environment, :development
   set :show_exceptions, false
+end
+
+RSpec.configure do |config|
+  config.before(:each, js: true, type: :feature) do
+    # typekit raises js error which crashes poltergeist
+    page.driver.browser.url_blacklist = %w(http://use.typekit.net)
+  end
 end


### PR DESCRIPTION
Fixes #47 

Adds
* rspec
* rake
* capybara
* poltergeist

Bonus:
* I do not have access to the contentful api, therefore I was unable to run `middleman contentful`. I have added the [Safe Navigator Operator](http://mitrev.net/ruby/2015/11/13/the-operator-in-ruby/), before trying to loop over the mysterious `@post` instance variable. 
* When running the integration test with javascript errors enabled, poltergeist raises an js error from the typekit javascript (because the 127.0.0.1 is not whitelisted domain). Capybara provides `page.driver.browser.url_blacklist` to block the url

