### PR TITLE
Upgrade Nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'middleman-dotenv'
 gem 'middleman-syntax'
 gem 'middleman-autoprefixer'
 gem 'middleman-search_engine_sitemap'
+gem 'nokogiri', '~> 1.8.1'
 
 gem 'slim'
 gem 'html2slim' # Use `bundle exec erb2slim|html2slim -h` for more info

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,11 +123,11 @@ GEM
     mime-types (3.0)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2015.1120)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.3.0)
     minitest (5.8.3)
     multi_json (1.11.2)
-    nokogiri (1.6.7.1)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     padrino-helpers (0.12.5)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.12.5)
@@ -186,6 +186,7 @@ DEPENDENCIES
   middleman-livereload
   middleman-search_engine_sitemap
   middleman-syntax
+  nokogiri (~> 1.8.1)
   slim
   tzinfo-data
   wdm (~> 0.1.0)


### PR DESCRIPTION
Previous version had a security vulernability:
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9050