### PR TITLE
Use rouges class for gutter style

### DIFF
--- a/source/stylesheets/modules/_syntax.scss
+++ b/source/stylesheets/modules/_syntax.scss
@@ -1,7 +1,7 @@
 $background-color: #2d2d2d;
 $default-text-color: #eaeaea;
 
-td.code {
+td.code, td.rouge-code {
   padding: 5px 5px 5px 10px;
 }
 

--- a/source/stylesheets/modules/_syntax.scss
+++ b/source/stylesheets/modules/_syntax.scss
@@ -81,7 +81,7 @@ td.code {
   pre {
     overflow-x: auto;
   }
-  .gutter {
+  .rouge-gutter, .gutter {
     width: 2.5em;
     text-align: center !important;
   }


### PR DESCRIPTION
Fixes #95, as the gutter element has `.gl` and `.rouge-gutter` class. Perhaps it was different before? 🤷‍♀️