### PR TITLE
Prevent font ligatures as `ff` looks weird

### DIFF
--- a/source/stylesheets/modules/_syntax.scss
+++ b/source/stylesheets/modules/_syntax.scss
@@ -80,6 +80,7 @@ td.code, td.rouge-code {
   }
   pre {
     overflow-x: auto;
+    font-feature-settings: normal;
   }
   .rouge-gutter, .gutter {
     width: 2.5em;


### PR DESCRIPTION
Turns out the font we use has font ligatures turned on, so in the case of `ff` in code examples those two letters are very close to each other. The example can be found in https://www.theguild.nl/you-dont-have-to-choose/

![woff_ligature](https://user-images.githubusercontent.com/51889/54023944-9871b780-4196-11e9-839d-25ca1943c4af.png)

[credits to @RoelN for helping to figure this out]