### PR TITLE
Fix responsiveness of navbar

### DIFF
--- a/source/stylesheets/modules/_nav.scss
+++ b/source/stylesheets/modules/_nav.scss
@@ -1,34 +1,25 @@
 nav {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 5vh;
+  max-width: 50em;
+  margin: 0 auto 1.2em auto;
 
   ul {
     align-self: flex-end;
     display: flex;
-    margin:0 auto;
-    width: 25vw;
+    flex-direction: row;
   }
 
   li {
     flex: 1;
-    padding: .5em .75em;
+    padding: .75em 0;
     text-align: center;
   }
 
   a {
     text-decoration: none;
+    white-space: nowrap;
   }
 
   .active {
     border-bottom: .1em solid $brand-primary;
-  }
-}
-
-@media screen and (max-width: 768px) {
-  nav {
-    ul {
-      width: 100vw;
-    }
   }
 }


### PR DESCRIPTION
# Changelog

* fix alignment and white-space wrap for navbar
The icon and text were breaking on the next line, in smaller
screensizes. This now uses the max-width like the header hero component.