### PR TITLE
Fix/social media tags

### DIFF
--- a/data/config.yml
+++ b/data/config.yml
@@ -3,7 +3,7 @@ site_subtitle: The Guild — A Blog About Development and Geekery
 description: A blog about development and geekery
 author: Kabisa
 email: info@kabisa.nl
-site_url: http://www.theguild.nl
+site_url: https://www.theguild.nl
 feed_path: /feed.xml
 twitteraccount: '@theguildtech'
 

--- a/helpers/social_media_helpers.rb
+++ b/helpers/social_media_helpers.rb
@@ -10,7 +10,7 @@ module SocialMediaHelpers
   end
 
   def current_page_url
-    "#{config.site_url}#{current_page.url}"
+    "#{data.config.site_url}#{current_page.url}"
   end
 
   def page_twitter_card_type

--- a/source/partials/_footer.html.slim
+++ b/source/partials/_footer.html.slim
@@ -47,6 +47,6 @@ footer.site-footer role="contentinfo"
     .column-content
       .footer-menu
         li
-          a href="http://kabisa.nl/disclaimer" target="_blank" Disclaimer
+          a href="https://kabisa.nl/disclaimer" target="_blank" Disclaimer
         li
-          a href="http://kabisa.nl/privacy-statement" target="_blank" Privacy Statement
+          a href="https://kabisa.nl/privacy-statement" target="_blank" Privacy Statement

--- a/source/partials/_header.html.slim
+++ b/source/partials/_header.html.slim
@@ -8,7 +8,7 @@ header.hero.hero-home
       h2= data.config.site_subtitle
       p
         | Written & Filmed by&nbsp;
-        a href="http://kabisa.nl/"
+        a href="https://kabisa.nl/"
           = data.config.author
       p
         | <script async defer src="https://theguildslacking.herokuapp.com/slackin.js"></script>


### PR DESCRIPTION
Adresses #66 - the root cause was indeed https://github.com/kabisa/theguild.nl/issues/66#issuecomment-172489327 by Roel

## Changelog
- add the correct website to the `helpers/social_media_helpers.rb`
- change `http` to `https`