### PR TITLE
add middleman-sprockets, since we are still using them

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'middleman-autoprefixer'
 gem 'middleman-dotenv'
 gem 'middleman-search_engine_sitemap'
 gem 'middleman-syntax'
+gem 'middleman-sprockets' # needed after MM 4.3 version
 gem 'nokogiri'
 
 gem 'builder' # XMLfeeds

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (9.7.4)
       execjs
-    backports (3.16.0)
+    backports (3.17.0)
     builder (3.2.4)
     capybara (3.31.0)
       addressable
@@ -82,18 +82,18 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.2)
     method_source (0.9.2)
-    middleman (4.3.5)
+    middleman (4.3.6)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
       kramdown (~> 1.2)
-      middleman-cli (= 4.3.5)
-      middleman-core (= 4.3.5)
+      middleman-cli (= 4.3.6)
+      middleman-core (= 4.3.6)
     middleman-autoprefixer (2.10.1)
       autoprefixer-rails (~> 9.1)
       middleman-core (>= 3.3.3)
-    middleman-cli (4.3.5)
+    middleman-cli (4.3.6)
       thor (>= 0.17.0, < 2.0)
-    middleman-core (4.3.5)
+    middleman-core (4.3.6)
       activesupport (>= 4.2, < 5.1)
       addressable (~> 2.3)
       backports (~> 3.6)
@@ -126,6 +126,9 @@ GEM
     middleman-search_engine_sitemap (1.4.0)
       builder
       middleman-core (~> 4.0)
+    middleman-sprockets (4.1.1)
+      middleman-core (~> 4.0)
+      sprockets (>= 3.0)
     middleman-syntax (3.2.0)
       middleman-core (>= 3.2)
       rouge (~> 3.2)
@@ -133,7 +136,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     multi_json (1.14.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)
@@ -155,11 +158,11 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (12.3.3)
+    rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (1.6.0)
+    regexp_parser (1.7.0)
     rich_text_renderer (0.2.2)
     rouge (3.16.0)
     rspec (3.9.0)
@@ -181,6 +184,9 @@ GEM
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
+    sprockets (4.0.0)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     temple (0.8.2)
     thor (1.0.1)
     thread_safe (0.3.6)
@@ -211,6 +217,7 @@ DEPENDENCIES
   middleman-dotenv
   middleman-livereload
   middleman-search_engine_sitemap
+  middleman-sprockets
   middleman-syntax
   nokogiri
   poltergeist
@@ -223,4 +230,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.0.1
+   1.17.2

--- a/config.rb
+++ b/config.rb
@@ -34,6 +34,12 @@ Dir['lib/mappers/*.rb'].each { |file| require file }
 # Automatic image dimensions on image_tag helper
 # activate :automatic_image_sizes
 
+# Since Middleman 4.3, sprockets have been removed, and require_tree is not
+# working anymore - Alternative is to go with webpack as an external pipeline
+activate :sprockets do |c|
+  c.supported_output_extensions = [".js"]
+end
+
 # Reload the browser automatically whenever files change
 configure :development do
   activate :livereload


### PR DESCRIPTION
* Otherwise the `require_tree .` does not work

I have broken the javascript files when updating to middleman 4.3