### PR TITLE
Use Rajdhani + system font stack

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -20,10 +20,10 @@ $shadow:       rgba($brand-dark, 0.75) 1px 1px 10px;
 $easing:       cubic-bezier(0.55, 0, 0.1, 1);
 
 // Typography
-$heading-font:    "brandon-grotesque", Arial, Verdana, sans-serif;
-$heading-weight:  100;
+$heading-font:    "rajdhani", sans-serif !default;
+$heading-weight:  600;
 
-$body-font:       "merriweather", Georgia, Times, "Times New Roman", serif;
+$body-font:       -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif !default;
 $bold:            700;
 $normal:          300;
 $line-height:     1.5;


### PR DESCRIPTION
To match kabisa.nl and blog.kabisa.nl.

**Before**

![before-1](https://user-images.githubusercontent.com/304603/76599154-ad4cfd80-6504-11ea-9eed-831e3f187cec.png)
![before-2](https://user-images.githubusercontent.com/304603/76599156-ae7e2a80-6504-11ea-8bdd-59ecfbf40401.png)

**After**

![after-1](https://user-images.githubusercontent.com/304603/76599171-b63dcf00-6504-11ea-978a-954c2199fefe.png)
![after-2](https://user-images.githubusercontent.com/304603/76599173-b76efc00-6504-11ea-8ff6-8a5775343af6.png)
